### PR TITLE
fix: Restore composite layers and add comments on scaling

### DIFF
--- a/jules-scratch/verification/verify_composite.py
+++ b/jules-scratch/verification/verify_composite.py
@@ -6,7 +6,7 @@ def run():
         page = browser.new_page()
         # Give the server a moment to respond
         try:
-            page.goto("http://localhost:8787", timeout=10000)
+            page.goto("http://localhost:8788", timeout=10000)
             # Wait for the image to be loaded if it's an image tag
             # In our case, the response is the image itself, so no need to wait for a selector
             page.screenshot(path="jules-scratch/verification/verification.png")

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,13 @@ interface Env {
 
 async function fetchCompositeImage(isoDate: string, apiKey: string): Promise<ArrayBuffer> {
 	// Layering LASCO C2 (sourceId 4) as the base and AIA 171 (sourceId 10) on top.
-	const layers = `[4,1,100],[10,1,100]`;
+	const layers = `[[4,1,100],[10,1,100]]`;
 	// This value may need to be tuned to get the scaling right between the two instruments.
+	// The SOHO/LASCO C2 instrument has a much wider field of view than SDO/AIA.
+	// A value of ~0.5 might be a good starting point for LASCO C2, while AIA 171 might need a different scale.
+	// The takeScreenshot API seems to apply the same scale to all layers, which might be the source of the problem.
+	// A potential solution is to make two separate requests and composite them manually,
+	// or to find a scale that works reasonably well for both.
 	const imageScale = 2.5;
 	const width = 1920;
 	const height = 1200;


### PR DESCRIPTION
This change addresses a bug where the composite image was reportedly showing two SDO images instead of an SDO and a SOHO image.

My investigation suggests that this is not due to incorrect layer IDs, but rather due to the `imageScale` parameter being applied uniformly to both layers, which have very different fields of view.

This commit restores the two-layer composite in the code and adds detailed comments explaining the `imageScale` issue and suggesting potential solutions for you to explore.

Due to some instability in my development environment, I was unable to visually test different `imageScale` values to find the optimal one. This commit provides you with the corrected code structure and the necessary information to fine-tune the visual output.